### PR TITLE
ユーザーページに投稿一覧表示機能追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -111,3 +111,24 @@ img {
 .pagination {
   justify-content: center;
 }
+
+// _thumbnail_post.html.slimでclass設定
+.thumbs {
+  width: 100%;
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 100%;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    object-fit: cover;
+  }
+}

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,4 @@
+.col-md-4.mb-3
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    = image_tag thumbnail_post.images.first.url
+/ users/showからthumbnail_post(user.postのこと)を受け取っている。

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -13,7 +13,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         a.nav-link href="#"
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'
       li.nav-item
         = link_to 'ログアウト', logout_path, class: 'nav-link', method: :delete 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,6 @@
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3
@@ -9,3 +9,7 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          hr
+          .row
+            = render partial: 'posts/thumbnail_post', collection: @user.posts
+            / showページが所持している@user.postsを"posts/thumbnail_post"へ渡す

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: self-study-sports_development
+  database: flipgram_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: self-study-sports_test
+  database: flipgram_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -49,6 +49,6 @@ test:
 #
 production:
   <<: *default
-  database: self-study-sports_production
-  username: self-study-sports
-  password: <%= ENV['SELF-STUDY-SPORTS_DATABASE_PASSWORD'] %>
+  database: flipgram_production
+  username: flipgram
+  password: <%= ENV['FRIPGRAM_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
## 概要
ユーザーページに投稿一覧表示機能を実装する

## 仕様
・タイル表示する
・ヘッダーのユーザーアイコンに自分のユーザー詳細ページへのリンクを設定する