### PR TITLE
プロフィール編集機能の実装

### DIFF
--- a/app/assets/javascripts/mypage.js
+++ b/app/assets/javascripts/mypage.js
@@ -1,0 +1,33 @@
+//= require jquery3
+//= require popper
+//= require rails-ujs
+//= require bootstrap-material-design/dist/js/bootstrap-material-design.js
+
+// onchangeイベントによりファイルを選択すると発火。
+// 即時プレビューを表示させるためのJS
+function previewFileWithId(selector) {
+  // 操作する要素を引数'selector'として受け取っており'image_tag'が入っているイメージ
+  // この関数のゴールは、image_tagが持つHTML属性である"src"を差し替えること。
+
+  const target = this.event.target;
+  // event.targetでイベント発生源である要素を取得できる。
+  const file = target.files[0];
+  // event.targetにはfilesというプロパティが設定されていて、"File"というオブジェクトが配列のように管理されている。
+  const reader  = new FileReader();
+  // ファイルを読み込むためのFileReaderオブジェクトを定義
+
+  if (file) {
+    reader.readAsDataURL(file);
+    // Fileオブジェクトが取得できた場合。
+    // readAsDataURL()はFileReaderの読取メソッドで、FileオブシェクトのURLを読み込む。
+  } else {
+    selector.src = "";
+  }
+
+  reader.onloadend = function () {
+    // onloardendはFileReaderのイベント。データの読み込みが終了した時に発火し、設定した関数が呼び出され実行される。
+      selector.src = reader.result;
+      // FileReaderのresultプロパティ。読み取り操作が完了した後でのみ有効となり、データの形式は読取メソッドの種類により異なる。
+      // 読み込んだファイルの結果を"selector.src"に当てている。
+  }
+}

--- a/app/assets/javascripts/mypage.js
+++ b/app/assets/javascripts/mypage.js
@@ -1,4 +1,4 @@
-//= require jquery3
+//= require jquery
 //= require popper
 //= require rails-ujs
 //= require bootstrap-material-design/dist/js/bootstrap-material-design.js

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -1,0 +1,7 @@
+@import 'bootstrap-material-design/dist/css/bootstrap-material-design';
+@import 'font-awesome-sprockets';
+@import 'font-awesome';
+
+main {
+  padding-top: 50px;
+}

--- a/app/controllers/mypage/accounts_controller.rb
+++ b/app/controllers/mypage/accounts_controller.rb
@@ -10,7 +10,7 @@ class Mypage::AccountsController < Mypage::BaseController
     # ログイン中のユーザーを@userとする
     if @user.update(account_params)
       # @userをaccount_paramsの内容で上書きする
-      redirect_to edit_mypage_account_path, success: 'プロフィールを更新しました'
+      redirect_to user_path(current_user), success: 'プロフィールを更新しました'
     else
       flash.now[:danger] = 'プロフィールの更新に失敗しました'
       render :edit

--- a/app/controllers/mypage/accounts_controller.rb
+++ b/app/controllers/mypage/accounts_controller.rb
@@ -1,0 +1,28 @@
+class Mypage::AccountsController < Mypage::BaseController
+
+  def edit
+    @user = User.find(current_user.id)
+    # ログイン中のユーザーを@userとする
+  end
+
+  def update
+    @user = User.find(current_user.id)
+    # ログイン中のユーザーを@userとする
+    if @user.update(account_params)
+      # @userをaccount_paramsの内容で上書きする
+      redirect_to edit_mypage_account_path, success: 'プロフィールを更新しました'
+    else
+      flash.now[:danger] = 'プロフィールの更新に失敗しました'
+      render :edit
+    end
+  end
+
+  private
+
+  def account_params
+    params.require(:user).permit(:username, :avatar, :avatar_cache)
+    # 現段階では、usernameとavatarのみ編集できるような作りになっている。
+    # avatar_cacheは、carrerwaveの機能でアップロードしたファイルを一時保存してくれる機能。
+    # バリデーションエラーなどでファイル消失したときに、ここから取り出せる。
+  end
+end

--- a/app/controllers/mypage/base_controller.rb
+++ b/app/controllers/mypage/base_controller.rb
@@ -1,0 +1,7 @@
+class Mypage::BaseController < ApplicationController
+  before_action :require_login
+  layout 'mypage'
+  # レイアウトファイル名を指定。これでlayouts/mypage.html.slimが適用される。
+end
+# 今後マイページに機能を追加していくと、mypageディレクトリのコントローラー数が増えていく。
+# なのでApplicationControllerの機能をいったんbasecontrollerで受け取り、マイページ共通の処理はこちらに書いていくのが良い

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  mount_uploader :avatar, AvatarUploader
+
   has_many :posts, dependent: :destroy
   # userは複数のpostを持つというアソシエーション
   # userとpost両方ともアソシエーションを記入する必要がある

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,49 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+  # リサイズ等画像の加工処理をするにはMiniMagickが必要
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # デフォルト画像の設定
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url
+    'profile-placeholder.png'
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+  
+  # 画像の横幅・縦幅の最大値設定。どちらかが超えてしまう場合は最大値に合わせてリサイズされる。
+  process resize_to_limit: [400, 400]
+end

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,7 +1,7 @@
 div id="comment-#{comment.id}"
   .row.no-gutters
     .col-2
-      = image_tag 'profile-placeholder.png', size: '40x40', class: 'rounded-circle'
+      = image_tag comment.user.avatar.url, size: '40x40', class: 'rounded-circle'
     .col-9
       span.font-weight-bold.pr-1
         = comment.user.username

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,7 +4,7 @@ html
     meta content=("text/html; charset=UTF-8") http-equiv="Content-Type" /
     meta[name="viewport" content="width=device-width, initial-scale=1.0"]
     title
-      | SelfStudySports
+      | Flipgram
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all'

--- a/app/views/layouts/mypage.html.slim
+++ b/app/views/layouts/mypage.html.slim
@@ -1,0 +1,25 @@
+doctype html
+html
+  head
+    meta content=("text/html; charset=UTF-8") http-equiv="Content-Type" /
+    meta[name="viewport" content="width=device-width, initial-scale=1.0"]
+    title マイページ | Flipgram
+    = csrf_meta_tags
+    = csp_meta_tag
+    = stylesheet_link_tag 'mypage', media: 'all'
+    = javascript_include_tag 'mypage'
+  body
+    = render 'shared/header'
+    = render 'shared/flash_messages'
+    main
+      .container
+        .row
+          .col-md-8.offset-md-2
+            .card
+              .card-body
+                .row
+                  .col-md-3
+                    = render 'mypage/shared/sidebar'
+                  .col-md-9
+                    .mypage_content
+                      = yield

--- a/app/views/mypage/accounts/edit.html.slim
+++ b/app/views/mypage/accounts/edit.html.slim
@@ -1,0 +1,15 @@
+= form_with model: @user, url: mypage_account_path, method: :patch, local: true do |f|
+  / method: :patchとすることで、情報の送信先がeditアクションとなる。
+  = render 'shared/error_messages', object: f.object
+  .form-group
+    = f.label :avatar
+    = f.file_field :avatar, onchange: 'previewFileWithId(preview)', class: 'form-control', accept: 'image/*'
+    / file_fieldがonchange(選択された)した時に、'previewFileWithId'が実行される。'preview'というidを元に操作するDOMを取得。
+    = f.hidden_field :avatar_cache
+    = image_tag @user.avatar.url, class: 'rounded-circle', id: 'preview', size: '100x100'
+    / onchangeイベントによって、'preview'というidを持っているimage_tagの画像url(src)が上書きされる。
+  .form-group
+    = f.label :username
+    = f.text_field :username, class: 'form-control'
+
+  = f.submit class: 'btn btn-primary btn-raised'

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -1,0 +1,5 @@
+nav
+  ul.list-unstyled
+    li
+      = link_to 'プロフィール編集', edit_mypage_account_path
+      hr

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -3,7 +3,7 @@
   .card-header
     .d-flex.align-items-center
       = link_to user_path(post.user) do
-        = image_tag 'profile-placeholder.png', size: '40x40', class: 'rounded-circle mr-1'
+        = image_tag post.user.avatar.url, size: '40x40', class: 'rounded-circle mr-1'
         = post.user.username
 
       / ログイン時かつ自身の投稿の場合は編集削除ができる分岐を導入する

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -17,7 +17,7 @@
       / ログインがtrueならば表示。logged_in?はsoceryのメソッド。
       - if logged_in?
         .profile-box.mb-3
-          = image_tag 'profile-placeholder.png', size: '50x50', class: 'rounded-circle mr-1'
+          = image_tag current_user.avatar.url, size: '50x50', class: 'rounded-circle mr-1'
           = current_user.username
 
       .users-box

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -18,7 +18,7 @@
       - if logged_in?
         .profile-box.mb-3
           = image_tag current_user.avatar.url, size: '50x50', class: 'rounded-circle mr-1'
-          = current_user.username
+          = link_to current_user.username, user_path(current_user)
 
       .users-box
         .card

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -10,7 +10,7 @@
   .image-info-box
     .profile-box.p-3
       .d-flex.align-items-center
-        = image_tag 'profile-placeholder.png', size: '40x40', class: 'rounded-circle mr-1'
+        = image_tag @post.user.avatar.url, size: '40x40', class: 'rounded-circle mr-1'
         = @post.user.username
         / ログイン時かつ自身の投稿の場合は編集削除ができる分岐を導入する
         - if logged_in? && @post.user_id == current_user.id
@@ -30,7 +30,7 @@
       / 投稿の本文
       .row.no-gutters
         .col-2
-          = image_tag 'profile-placeholder.png', size: '40x40', class: 'rounded-circle'
+          = image_tag @post.user.avatar.url, size: '40x40', class: 'rounded-circle'
         .col-10
           / railsのsimple_formatメソッドを使用し、入力時の改行等を反映できるようにする
           = simple_format(@post.body)

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -1,5 +1,5 @@
 nav.navbar.navbar-expand-lg.navbar-light.bg-white
-  = link_to 'ShareApp', root_path, class: 'navbar-brand'
+  = link_to 'Flipgram', root_path, class: 'navbar-brand'
 
   / トグルメニューの記載
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,5 +1,5 @@
 nav.navbar.navbar-expand-lg.navbar-light.bg-white
-  = link_to 'ShareApp', root_path, class: 'navbar-brand'
+  = link_to 'Flipgram', root_path, class: 'navbar-brand'
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
   #navbarTogglerDemo02.collapse.navbar-collapse

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,6 +1,6 @@
 .user.mb-3.d-flex.justify-content-between
   = link_to user_path(user) do
-    = image_tag 'profile-placeholder.png', size: '40x40', class: 'rounded-circle mr-1'
+    = image_tag user.avatar.url, size: '40x40', class: 'rounded-circle mr-1'
     = user.username
   = render 'users/follow_area', user: user
 hr

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,7 +8,7 @@
             .text-center.mb-3
               = link_to 'プロフィール編集', edit_mypage_account_path, class: 'btn btn-raised btn-warning'
           .text-center.mb-3
-            = image_tag 'profile-placeholder.png', size: '100x100', class: 'rounded-circle mr-1'
+            = image_tag @user.avatar.url, size: '100x100', class: 'rounded-circle mr-1'
           .profile.text-center.mb-3
             = @user.username
           .text-center

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,6 +3,10 @@
     .col-md-10.offset-md-1
       .card
         .card-body
+          - if logged_in? && current_user.id == @user.id
+            / 未ログインの場合は短絡評価が適用されるのでcurrent_user=>nilによるエラーにはならない。
+            .text-center.mb-3
+              = link_to 'プロフィール編集', edit_mypage_account_path, class: 'btn btn-raised btn-warning'
           .text-center.mb-3
             = image_tag 'profile-placeholder.png', size: '100x100', class: 'rounded-circle mr-1'
           .profile.text-center.mb-3

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( mypage.js mypage.css )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,13 @@ Rails.application.routes.draw do
   resources :likes, only: %i[create destroy]
   resources :relationships, only: %i[create destroy]
 
+  namespace :mypage do
+    resource :account, only: %i[edit update]
+  end
+  # namespaceでコントローラーをグループ化する。(今はaccountsコントローラーのみだが、今後増えることを想定した実装となる)
+  # この記述で、/"namespace名"/"コントローラー名"というパスを得る。
+  # 自分自身に対しての処理のため単一resourceメソッドを用いた。
+
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20200825114734_sorcery_core.rb
+++ b/db/migrate/20200825114734_sorcery_core.rb
@@ -5,7 +5,7 @@ class SorceryCore < ActiveRecord::Migration[5.2]
       t.string :crypted_password
       t.string :salt
       t.string :username, null: false
-
+      t.string :avatar
       t.timestamps                null: false
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2020_09_09_131016) do
     t.string "crypted_password"
     t.string "salt"
     t.string "username", null: false
+    t.string "avatar"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要
プロフィール編集機能の実装
## 実装内容
マイページからusername、アバターを変更できるようにする。

## 仕様
・編集画面は/mypage/account/editというパスとする
・アバター選択時（ファイル選択時）にプレビューを表示する
・image_magickを使用して、画像は横幅or縦幅が最大400pxとなるようにリサイズする
・今後の機能追加を考慮したマイページ設計とする